### PR TITLE
feat: add product detail page with dynamic routing

### DIFF
--- a/components/layouts/CategorySection.tsx
+++ b/components/layouts/CategorySection.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Table from "@/public/images/table.jpeg";
 import Sofa from "@/public/images/sofa.jpeg";
 import Chair1 from "@/public/images/chair1.jpeg";
+import Link from "next/link";
 
 export default function CategorySection() {
   return (
@@ -11,27 +12,33 @@ export default function CategorySection() {
           <Image src={Table} alt="Table" priority></Image>
         </div>
         <p className="my-2">自然木紋桌款</p>
-        <button className="outline rounded-full px-3 py-1 cursor-pointer hover:bg-white">
-          探索更多
-        </button>
+        <Link href="/product/table">
+          <button className="outline rounded-full px-3 py-1 cursor-pointer hover:bg-white">
+            探索更多
+          </button>
+        </Link>
       </div>
       <div className=" flex flex-col items-center">
         <div className="w-20 h-20 rounded-full overflow-hidden md:w-30 md:h-30 lg:w-50 lg:h-50">
           <Image src={Sofa} alt="Sofa" priority></Image>
         </div>
         <p className="my-2">舒適慵懶沙發</p>
-        <button className="outline rounded-full px-3 py-1 cursor-pointer hover:bg-white">
-          探索更多
-        </button>
+        <Link href="/product/sofa">
+          <button className="outline rounded-full px-3 py-1 cursor-pointer hover:bg-white">
+            探索更多
+          </button>
+        </Link>
       </div>
       <div className=" flex flex-col items-center">
         <div className="w-20 h-20 rounded-full overflow-hidden md:w-30 md:h-30 lg:w-50 lg:h-50">
           <Image src={Chair1} alt="Chair" priority></Image>
         </div>
         <p className="my-2">風格單椅專區</p>
-        <button className="outline rounded-full px-3 py-1 cursor-pointer hover:bg-white">
-          探索更多
-        </button>
+        <Link href="/product/chair">
+          <button className="outline rounded-full px-3 py-1 cursor-pointer hover:bg-white">
+            探索更多
+          </button>
+        </Link>
       </div>
     </div>
   );

--- a/components/layouts/Footer.tsx
+++ b/components/layouts/Footer.tsx
@@ -1,18 +1,19 @@
 import Image from "next/image";
 import LOGO from "@/public/images/logo.png";
+import Link from "next/link";
 
 export default function Slogan() {
   return (
     <div className="bg-Coffee flex justify-around items-center py-2 px-2">
       <div className="bg-white rounded-full w-15 h-15 flex items-center lg:w-20 lg:h-20">
-        <a href="#">
+        <Link href="/">
           <Image src={LOGO} alt="logo"></Image>
-        </a>
+        </Link>
       </div>
       <div>
-        <a href="#">
+        <Link href="/about">
           <h3 className="text-white cursor-pointer">關於我們</h3>
-        </a>
+        </Link>
       </div>
       <div>
         <a href="#">

--- a/components/layouts/HeroSection.tsx
+++ b/components/layouts/HeroSection.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Chair from "@/public/images/chair.jpeg";
 import LOGO from "@/public/images/logo.png";
+import Link from "next/link";
 
 export default function HeroSection() {
   return (
@@ -15,11 +16,11 @@ export default function HeroSection() {
         <p className="text-white mt-2 text-center px-3 md:text-2xl md:px-15 md:mt-5 lg:px-30 xl:text-4xl xl:px-40">
           帶來自然與舒適的居家時光
         </p>
-        <a href="#">
+        <Link href="/product">
           <button className="px-5 py-1 border-2 border-white text-white md:mt-2 lg:mt-8 xl:text-2xl cursor-pointer">
             進入選品
           </button>
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/components/ui/Accordion.tsx
+++ b/components/ui/Accordion.tsx
@@ -1,0 +1,52 @@
+import { FaAngleDown } from "react-icons/fa";
+import { useState } from "react";
+
+export default function Accordion() {
+  const [openStyle, setOpenStyle] = useState<boolean>(false);
+  const [openMaterial, setOpenMaterial] = useState<boolean>(false);
+
+  return (
+    <>
+      <div className="border-t-1 mt-8 py-4 hover:underline cursor-pointer">
+        <button
+          type="button"
+          className="flex w-full hover:underline cursor-pointer"
+          onClick={() => setOpenStyle((prev) => !prev)}
+        >
+          <span className="font-bold">產品風格</span>
+          <FaAngleDown
+            className={`ml-auto transition-transform duration-300 ease-in-out ${openStyle ? "rotate-180" : "rotate-0"}`}
+          />
+        </button>
+      </div>
+
+      <div
+        className={`overflow-hidden transition-all duration-300 ease-in-out ${
+          openStyle ? "opacity-100 max-h-40" : "opacity-0 max-h-0"
+        }`}
+      >
+        <p className="text-gray-500 leading-7 mb-4">極簡北歐、現代工業風</p>
+      </div>
+
+      <div
+        className="border-t-1 py-4 hover:underline cursor-pointer"
+        onClick={() => setOpenMaterial((prev) => !prev)}
+      >
+        <button type="button" className="flex w-full cursor-pointer">
+          <span className="font-bold">產品材質</span>
+          <FaAngleDown
+            className={`ml-auto transition-transform duration-300 ease-in-out ${openMaterial ? "rotate-180" : "rotate-0"}`}
+          />
+        </button>
+      </div>
+
+      <div
+        className={`overflow-hidden transition-all duration-300 ease-in-out ${
+          openMaterial ? "opacity-100 max-h-40" : "opacity-0 max-h-0"
+        }`}
+      >
+        <p className="text-gray-500 leading-7 mb-4">高密度實木板搭配實木桌腳</p>
+      </div>
+    </>
+  );
+}

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -13,10 +13,13 @@ export default function Breadcrumbs() {
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean);
 
-  const crumbs = segments.map((segment, index) => {
-    const href = "/" + segments.slice(0, index + 1).join("/");
-    return { label: labelMap[segment] || segment, href };
-  });
+  // 只留下有在 labelMap 裡的 segments
+  const crumbs = segments
+    .filter((segment) => labelMap[segment]) // 過濾掉不是在 labelMap 裡面的（也就是像 id 這種動態的）
+    .map((segment, index) => {
+      const href = "/" + segments.slice(0, index + 1).join("/");
+      return { label: labelMap[segment] || segment, href };
+    });
 
   return (
     <nav className="text-sm flex space-x-2 ml-10 mt-5 mb-3 xl:ml-30 xl:mb-8">

--- a/components/ui/MobileMenu.tsx
+++ b/components/ui/MobileMenu.tsx
@@ -2,6 +2,8 @@ import { MobileMenuProps } from "@/types/menu";
 import { MdNavigateNext } from "react-icons/md";
 import { BsCart3 } from "react-icons/bs";
 import { GrContact } from "react-icons/gr";
+import { BsFillTelephoneFill } from "react-icons/bs";
+import Link from "next/link";
 
 export default function MobileMenu({ isOpen, setIsOpen }: MobileMenuProps) {
   return (
@@ -29,22 +31,38 @@ export default function MobileMenu({ isOpen, setIsOpen }: MobileMenuProps) {
               </button>
             </div>
             <div className="space-y-4 mt-10">
-              <button className="flex justify-between items-center w-full text-3xl cursor-pointer">
+              <Link
+                href="/product"
+                className="flex justify-between items-center w-full text-3xl cursor-pointer"
+                onClick={() => setIsOpen(false)}
+              >
                 <h3 className="text-2xl font-bold">新品</h3>
                 <MdNavigateNext />
-              </button>
-              <button className="flex justify-between items-center w-full text-3xl cursor-pointer">
+              </Link>
+              <Link
+                href="/product/sofa"
+                className="flex justify-between items-center w-full text-3xl cursor-pointer"
+                onClick={() => setIsOpen(false)}
+              >
                 <h3 className="text-2xl font-bold">沙發</h3>
                 <MdNavigateNext />
-              </button>
-              <button className="flex justify-between items-center w-full text-3xl cursor-pointer">
+              </Link>
+              <Link
+                href="/product/table"
+                className="flex justify-between items-center w-full text-3xl cursor-pointer"
+                onClick={() => setIsOpen(false)}
+              >
                 <h3 className="text-2xl font-bold">桌子</h3>
                 <MdNavigateNext />
-              </button>
-              <button className="flex justify-between items-center w-full text-3xl cursor-pointer">
+              </Link>
+              <Link
+                href="/product/chair"
+                className="flex justify-between items-center w-full text-3xl cursor-pointer"
+                onClick={() => setIsOpen(false)}
+              >
                 <h3 className="text-2xl font-bold">椅子</h3>
                 <MdNavigateNext />
-              </button>
+              </Link>
             </div>
 
             <div className="mt-20">
@@ -52,23 +70,47 @@ export default function MobileMenu({ isOpen, setIsOpen }: MobileMenuProps) {
                 成為會員，體驗優質產品並掌握相關動態。
               </h1>
               <div className="flex gap-3 mt-8">
-                <button className="rounded-full py-1 flex-1 bg-black text-white cursor-pointer">
+                <Link
+                  href="/register"
+                  className="rounded-full py-1 flex-1 bg-black text-white cursor-pointer flex justify-center"
+                  onClick={() => setIsOpen(false)}
+                >
                   註冊
-                </button>
-                <button className="rounded-full flex-1 outline cursor-pointer">
+                </Link>
+                <Link
+                  href="/login"
+                  className="rounded-full py-1 flex-1 outline cursor-pointer flex justify-center"
+                  onClick={() => setIsOpen(false)}
+                >
                   登入
-                </button>
+                </Link>
               </div>
 
               <div className="mt-30 flex flex-col gap-6">
-                <div className="flex gap-3 text-2xl font-medium cursor-pointer">
+                <Link
+                  href="/cart"
+                  className="flex gap-3 text-2xl font-medium cursor-pointer"
+                  onClick={() => setIsOpen(false)}
+                >
                   <BsCart3 />
                   <span>購物車</span>
-                </div>
-                <div className="flex gap-3 text-2xl font-medium cursor-pointer">
+                </Link>
+                <Link
+                  href="/about"
+                  className="flex gap-3 text-2xl font-medium cursor-pointer"
+                  onClick={() => setIsOpen(false)}
+                >
                   <GrContact />
-                  <span>聯絡我們</span>
-                </div>
+                  <span>關於我</span>
+                </Link>
+                <Link
+                  href="/"
+                  className="flex gap-3 text-2xl font-medium cursor-pointer"
+                  onClick={() => setIsOpen(false)}
+                >
+                  <BsFillTelephoneFill />
+                  <span>聯絡我</span>
+                </Link>
               </div>
             </div>
           </div>

--- a/components/ui/Navbar.tsx
+++ b/components/ui/Navbar.tsx
@@ -7,6 +7,7 @@ import { FaUser } from "react-icons/fa";
 import { MdOutlineMenu } from "react-icons/md";
 import { useState } from "react";
 import MobileMenu from "./MobileMenu";
+import Link from "next/link";
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -15,44 +16,44 @@ export default function Navbar() {
     <>
       <div className="bg-white w-full flex items-center justify-between px-2 md:px-10">
         <div>
-          <a href="/.">
+          <Link href="/.">
             <Image src={LOGO} alt="logo" className="w-40" priority></Image>
-          </a>
+          </Link>
         </div>
 
         <div className="hidden lg:block">
           <ul className="flex lg:gap-15 xl:gap-30">
             <li>
-              <a
-                href="#"
+              <Link
+                href="/product"
                 className="relative inline-flex items-center gap-1 after:inline-block after:ml-1 after:align-middle after:content-[''] after:border-t-[0.3em] after:border-r-[0.3em] after:border-l-[0.3em] after:border-b-0 after:border-solid after:border-transparent after:border-t-black"
               >
                 新品
-              </a>
+              </Link>
             </li>
             <li>
-              <a
-                href="#"
+              <Link
+                href="/product/sofa"
                 className="relative inline-flex items-center gap-1 after:inline-block after:ml-1 after:align-middle after:content-[''] after:border-t-[0.3em] after:border-r-[0.3em] after:border-l-[0.3em] after:border-b-0 after:border-solid after:border-transparent after:border-t-black"
               >
                 沙發
-              </a>
+              </Link>
             </li>
             <li>
-              <a
-                href="#"
+              <Link
+                href="/product/table"
                 className="relative inline-flex items-center gap-1 after:inline-block after:ml-1 after:align-middle after:content-[''] after:border-t-[0.3em] after:border-r-[0.3em] after:border-l-[0.3em] after:border-b-0 after:border-solid after:border-transparent after:border-t-black"
               >
                 桌子
-              </a>
+              </Link>
             </li>
             <li>
-              <a
-                href="#"
+              <Link
+                href="/product/chair"
                 className="relative inline-flex items-center gap-1 after:inline-block after:ml-1 after:align-middle after:content-[''] after:border-t-[0.3em] after:border-r-[0.3em] after:border-l-[0.3em] after:border-b-0 after:border-solid after:border-transparent after:border-t-black"
               >
                 椅子
-              </a>
+              </Link>
             </li>
           </ul>
         </div>
@@ -73,12 +74,15 @@ export default function Navbar() {
           </div>
 
           <div className="flex hover:bg-gray-200 hover:-translate-y-0.5 transition rounded-full w-8 h-8 items-center justify-center">
-            <a href="#">
+            <Link href="/cart">
               <BsCart3 size={20} />
-            </a>
+            </Link>
           </div>
 
-          <div className="group flex items-center cursor-pointer hover:bg-gray-200 hover:shadow-sm transition duration-200 ease-in-out rounded px-3 py-2">
+          <Link
+            href="/login"
+            className="group flex items-center cursor-pointer hover:bg-gray-200 hover:shadow-sm transition duration-200 ease-in-out rounded px-3 py-2"
+          >
             <FaUser
               className="text-base align-middle transform transition duration-200 group-hover:-translate-y-0.5"
               size={20}
@@ -86,7 +90,7 @@ export default function Navbar() {
             <span className="text-sm leading-none hidden lg:block ml-1">
               會員登入
             </span>
-          </div>
+          </Link>
 
           <div className="lg:hidden" onClick={() => setIsOpen(true)}>
             <MdOutlineMenu size={25} />

--- a/components/ui/ProductCard.tsx
+++ b/components/ui/ProductCard.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image";
 import Product1 from "@/public/images/product1.png";
+import Link from "next/link";
 
 export default function ProductCard() {
   return (
-    <>
+    <Link href="/product/table/1">
       <div className="cursor-pointer rounded-2xl hover:shadow-xl">
         <div>
           <Image src={Product1} alt="Product" priority></Image>
@@ -16,6 +17,6 @@ export default function ProductCard() {
           <p className="lg:lg:text-lg">黑色的桌子</p>
         </div>
       </div>
-    </>
+    </Link>
   );
 }

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -1,0 +1,91 @@
+import { SidebarProps } from "@/types/sidebar";
+import Accordion from "@/components/ui/Accordion";
+import { GiPencilRuler } from "react-icons/gi";
+
+export default function Sidebar({ openSection, setOpenSection }: SidebarProps) {
+  const isOpen = openSection != null;
+  return (
+    <>
+      {isOpen && (
+        <>
+          {/* 背景遮罩 */}
+          <div
+            className="fixed inset-0 bg-black opacity-30 z-40"
+            onClick={() => setOpenSection(null)}
+          ></div>
+        </>
+      )}
+
+      {/* 側邊欄 */}
+      <div
+        className={`fixed bottom-0 left-0 h-[800px] w-full px-5 py-5 bg-white z-50
+          transform transition-transform duration-700 ease-in-out
+          md:top-0 md:right-0 md:left-auto md:bottom-auto md:w-[400px] md:h-full
+          ${
+            openSection
+              ? "translate-y-0 md:translate-x-0"
+              : "translate-y-full md:translate-x-full"
+          }
+        `}
+      >
+        <div className="flex justify-end">
+          <button
+            className="text-2xl cursor-pointer"
+            onClick={() => setOpenSection(null)}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* 產品資訊 */}
+        {openSection === "info" && (
+          <>
+            <div className="space-y-4 mt-10">
+              <h1 className="text-2xl font-bold">產品資訊</h1>
+              <p className="text-gray-500 leading-10">
+                這款桌子以簡約設計為核心，搭配俐落線條與深色木質質感，無論是作為餐桌、書桌或會議桌都能完美融入各種空間。四隻圓錐形桌腳設計，提供穩固支撐，展現北歐風格的經典魅力。
+              </p>
+
+              <h3 className="text-xl font-bold">安全與法規</h3>
+              <p className="text-gray-500 leading-7">
+                這張桌子經過測試並符合相關的強度和耐用性標準。
+              </p>
+            </div>
+            <Accordion />
+          </>
+        )}
+
+        {/* 產品尺寸 */}
+        {openSection === "size" && (
+          <>
+            <div className="space-y-4 mt-10">
+              <h3 className="text-2xl font-bold">尺寸</h3>
+              <table className="w-full mt-8 border-t-1 border-t-gray-300">
+                <tbody className="my-2 justify-around text-gray-600">
+                  <tr className="border-b-1 border-b-gray-300">
+                    <td className="py-2 pl-3">長度:</td>
+                    <td>75公分</td>
+                  </tr>
+                  <tr className="border-b-1 border-b-gray-300">
+                    <td className="py-2 pl-3">寬度:</td>
+                    <td>70公分</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pl-3">高度:</td>
+                    <td>120公分</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div className="mt-8 border-b-1 border-b-gray-300 ">
+                <div className="flex justify-center items-center bg-red-400 mb-6 rounded-md">
+                  <GiPencilRuler size={20} color="white" />
+                  <p className="ml-2 text-lg text-white">可依需求客製</p>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app/product/table/[id]/page.tsx
+++ b/src/app/product/table/[id]/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Image from "next/image";
+import product1 from "@/public/images/product1.png";
+import product2 from "@/public/images/product1-1.png";
+
+import { MdNavigateNext } from "react-icons/md";
+import { IoCartOutline } from "react-icons/io5";
+import { MdOutlineNavigateNext } from "react-icons/md";
+import { GrFormPrevious } from "react-icons/gr";
+import { FaPlus } from "react-icons/fa";
+import { FaMinus } from "react-icons/fa";
+
+import { useState } from "react";
+import Sidebar from "@/components/ui/Sidebar";
+
+export default function Cart() {
+  const [openSection, setOpenSection] = useState<"info" | "size" | null>(null);
+  const [quantity, setQuantity] = useState<number>(0);
+
+  return (
+    <>
+      <div className="md:flex md:px-10 md:py-20 max-w-7xl mx-auto lg:gap-3">
+        <div className="md:flex md:flex-col md:flex-1/2 md:max-h-[32.8rem]">
+          <div className="relative bg-blue-400 md:flex md:items-center md:rounded-2xl md:overflow-hidden md:h-5/6">
+            <Image src={product1} alt="product"></Image>
+
+            <div className="absolute top-1/2 flex justify-between w-full px-4">
+              <div className="rounded-full bg-white w-8 h-8 flex items-center justify-center cursor-pointer">
+                <GrFormPrevious size={30} />
+              </div>
+              <div className="rounded-full bg-white w-8 h-8 flex items-center justify-center cursor-pointer">
+                <MdOutlineNavigateNext size={30} />
+              </div>
+            </div>
+          </div>
+          <div className="hidden md:flex md:mt-5 md:justify-between">
+            <Image
+              src={product2}
+              alt="product"
+              className="w-25 h-25 bg-amber-500 rounded-lg"
+            ></Image>
+            <Image
+              src={product2}
+              alt="product"
+              className="w-25 h-25 bg-amber-500 rounded-lg"
+            ></Image>
+            <Image
+              src={product2}
+              alt="product"
+              className="w-25 h-25 bg-amber-500 rounded-lg"
+            ></Image>
+          </div>
+        </div>
+        <div className="px-5 mt-5 md:flex-1/2">
+          <div>
+            <h1 className="text-2xl font-bold">現代極簡實木桌</h1>
+            <p className="mt-2 text-gray-500 leading-7">
+              這款桌子以簡約設計為核心，搭配俐落線條與深色木質質感，無論是作為餐桌、書桌或會議桌都能完美融入各種空間。四隻圓錐形桌腳設計，提供穩固支撐，展現北歐風格的經典魅力。
+            </p>
+            <div>
+              <div
+                className="border-t-1 mt-8 py-8 hover:underline cursor-pointer"
+                onClick={() => setOpenSection("info")}
+              >
+                <button type="button" className="flex w-full cursor-pointer">
+                  <span className="text-lg font-bold">產品資訊</span>
+                  <MdNavigateNext className="ml-auto" size={30} />
+                </button>
+              </div>
+              <div
+                className="border-t-1 py-8 hover:underline cursor-pointer"
+                onClick={() => setOpenSection("size")}
+              >
+                <button type="button" className="flex w-full cursor-pointer">
+                  <span className="text-lg font-bold">尺寸</span>
+                  <MdNavigateNext className="ml-auto" size={30} />
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-10 flex md:mt-3 lg:my-5">
+            <p className="text-2xl font-bold">$123</p>
+
+            {/* 折扣 */}
+            <div className="bg-black py-0.5 px-2 rounded-md ml-6 flex items-center">
+              <p className="text-white font-bold text-sm">50%</p>
+            </div>
+
+            {/* 原價格 */}
+            <div className="flex items-end ml-auto">
+              <p className="text-gray-500 font-bold line-through text-lg">
+                $246
+              </p>
+            </div>
+          </div>
+
+          <div className="md:flex md:gap-2 lg:gap-5">
+            <div className="w-full flex justify-between bg-Light-grayish-blue mt-10 py-2 px-10 rounded-lg md:flex-1/2 md:mt-5 lg:py-4">
+              <button
+                className="cursor-pointer"
+                onClick={() => setQuantity((prev) => Math.max(prev - 1, 0))}
+              >
+                <FaMinus />
+              </button>
+              <span className="font-bold w-8 text-center">{quantity}</span>
+              <button
+                className="cursor-pointer"
+                onClick={() => setQuantity((prev) => prev + 1)}
+              >
+                <FaPlus />
+              </button>
+            </div>
+            <button className="bg-blue-700 text-white flex items-center justify-center py-2 rounded-lg w-full mt-5 cursor-pointer font-bold md:py-0 md:flex-1/2">
+              <IoCartOutline className="mr-1" size={18} />
+              加入購物車
+            </button>
+          </div>
+        </div>
+      </div>
+      <Sidebar openSection={openSection} setOpenSection={setOpenSection} />
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,6 +10,7 @@
   --color-Beige: #e3ccb4;
   --color-Coffee: #2e270f;
   --color-Camel: #b58b67;
+  --color-Light-grayish-blue: hsl(223, 100%, 95%);
 }
 
 @theme inline {

--- a/types/sidebar.ts
+++ b/types/sidebar.ts
@@ -1,0 +1,4 @@
+export interface SidebarProps {
+  openSection: "info" | "size" | null;
+  setOpenSection: (section: "info" | "size" | null) => void;
+}


### PR DESCRIPTION
## ✨ 變更內容

- [x] 新增 Accordion 元件（components/ui/Accordion .tsx）
- [x] 新增 Sidebar元件（components/ui/Sidebar.tsx）
- [x] 新增 Breadcrumbs 元件（components/ui/Breadcrumbs.tsx）
- [x] 新增 單產品 畫面（src/app/product/table/[id]/page.tsx）

## 🧾 說明

- Accordion 查看產品資訊、風格、材質。
- Sidebar 查看產品尺寸。
- Breadcrumbs 顯示當前所在位置。

## ✅ 測試方式

- 本地執行後瀏覽：
  - `/product/[category]/[id]`：顯示單產品畫面
  - Breadcrumbs 在各頁面顯示正常。
  - Accordion 查看產品資訊、風格、材質功能正常。
  - Sidebar 查看產品尺寸功能正常。

## 📝 備註

- 尚未接 API，僅為畫面雛型。
